### PR TITLE
don't drop scala.js compiler plugin

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -44,7 +44,7 @@ object geo extends Module {
 
     override def ivyDeps = geo_ivy_deps
 
-    override def scalacPluginIvyDeps = plugins
+    override def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ plugins
 
 		override def sources = T.sources(
 			millSourcePath / src,
@@ -111,7 +111,7 @@ object web extends Module{
         ivy"in.nvilla::monadic-rx-cats::0.4.0-RC1"
 	  )
 
-	 override def scalacPluginIvyDeps = plugins
+	 override def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ plugins
 
 		override def millSourcePath = super.millSourcePath / up
 

--- a/web/client/src/group/research/aging/geometa/web/MainJS.scala
+++ b/web/client/src/group/research/aging/geometa/web/MainJS.scala
@@ -15,8 +15,7 @@ import scala.scalajs.js.annotation._
 import scala.util._
 import scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-@JSExportTopLevel("MainJS")
-object MainJS  extends LogSupport{
+object MainJS  extends App with LogSupport{
 
   implicit val interpreter = Interpreter[IO]
   type Reducer = PartialFunction[(states.State, actions.Action), states.State]


### PR DESCRIPTION
This PR tries to fix `web.client.fastOpt` failure. There are still issues that I don't know how to handle, but I believe that primary blocker is removed.